### PR TITLE
sanity object for email form labels

### DIFF
--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -16,6 +16,7 @@ import pageContent from './pages/pageContent'
 import techInfo from './techInfo/techInfo'
 import translationObjects from './translationObject/translationObject'
 import guardianInfo from './guardianInfo/guardianInfo'
+import joinEmailForm from './joinUsPage/joinEmailForm'
 
 export const schemaTypes = [
   navBar,
@@ -27,6 +28,7 @@ export const schemaTypes = [
   dictionaryContactInfo,
   positionEl,
   benefitsSection,
+  joinEmailForm,
   joinSection,
   joinUsPage,
   positionType,

--- a/schemas/joinUsPage/joinEmailForm.ts
+++ b/schemas/joinUsPage/joinEmailForm.ts
@@ -7,7 +7,7 @@ export default {
   fieldsets: [{ name: 'joinFormLabels', title: 'Email Form\'s Input Labels' }],
   fields: [
     {
-      type: 'string',
+      type: 'localeString',
       name: 'emailFormTitle',
       validation: (rule: Rule) => rule.required(),
     },

--- a/schemas/joinUsPage/joinEmailForm.ts
+++ b/schemas/joinUsPage/joinEmailForm.ts
@@ -7,6 +7,11 @@ export default {
   fieldsets: [{ name: 'joinFormLabels', title: 'Email Form\'s Input Labels' }],
   fields: [
     {
+      type: 'string',
+      name: 'emailFormTitle',
+      validation: (rule: Rule) => rule.required(),
+    },
+    {
       type: 'localeString',
       name: 'emailFormLabel',
       validation: (rule: Rule) => rule.required(),

--- a/schemas/joinUsPage/joinEmailForm.ts
+++ b/schemas/joinUsPage/joinEmailForm.ts
@@ -1,0 +1,36 @@
+import { Rule } from 'sanity'
+
+export default {
+  type: 'object',
+  title: 'Join email form',
+  name: 'joinEmailForm',
+  fieldsets: [{ name: 'joinFormLabels', title: 'Email Form\'s Input Labels' }],
+  fields: [
+    {
+      type: 'localeString',
+      name: 'emailFormLabel',
+      validation: (rule: Rule) => rule.required(),
+
+    },
+    {
+      type: 'localeString',
+      name: 'nameFormLabel',
+      validation: (rule: Rule) => rule.required(),
+    },
+    {
+      type: 'localeString',
+      name: 'ageFormLabel',
+      validation: (rule: Rule) => rule.required(),
+    },
+    {
+      type: 'localeString',
+      name: 'jobFormLabel',
+      validation: (rule: Rule) => rule.required(),
+    },
+    {
+      type: 'localeString',
+      name: 'relevantInfoFormLabel',
+      validation: (rule: Rule) => rule.required(),
+    },
+  ],
+}

--- a/schemas/joinUsPage/joinUsPage.ts
+++ b/schemas/joinUsPage/joinUsPage.ts
@@ -57,5 +57,12 @@ export default {
       title: 'Benefits Section',
       validation: (rule: Rule) => rule.required(),
     },
+    {
+      type: 'joinEmailForm',
+      name: 'joinEmailForm',
+      title: 'Join Us Email Form',
+      description: 'Email form to apply for positions at Hulen',
+      validation: (rule: Rule) => rule.required(),
+    },
   ],
 }


### PR DESCRIPTION
New object for keeping translations of the email-form labels.

Ignoring the lack of styling, it should become something like this in the frontend dependent on the language:

![image](https://github.com/user-attachments/assets/f4f819ce-3d65-420d-b874-0b55a38be5a6)
